### PR TITLE
상세페이지carousel 동영상 있을시 먼저 나오게 수정

### DIFF
--- a/src/main/webapp/WEB-INF/views/product/oneProduct.jsp
+++ b/src/main/webapp/WEB-INF/views/product/oneProduct.jsp
@@ -262,11 +262,47 @@
                         <div id="carouselExampleIndicators" class="carousel slide carousel-box" data-bs-ride="true">
                             <div class="carousel-inner detail-carousel">
                             	
-                            	<c:if test="${!empty oneProduct.video}">
-                                    <div class="carousel-item">
+                                
+                                <!-- 비디오 있을 때 -->
+                           	        <c:if test="${!empty oneProduct.video}">
+                                    <div class="carousel-item active">
                                         <video src="/upload/${oneProduct.video}" controls="controls"></video>
                                     </div>
+                                
+                                <c:if test="${!empty oneProduct.img1}">
+                                    <div class="carousel-item">
+                                        <img alt="상품이미지가 없습니다." src="/upload/${oneProduct.img1}">
+                                    </div>
                                 </c:if>
+                                <c:if test="${!empty oneProduct.img2}">
+                                    <div class="carousel-item">
+                                        <img alt="상품이미지가 없습니다." src="/upload/${oneProduct.img2}">
+                                    </div>
+                                </c:if>
+                                <c:if test="${!empty oneProduct.img3}">
+                                    <div class="carousel-item">
+                                        <img alt="상품이미지가 없습니다." src="/upload/${oneProduct.img3}">
+                                    </div>
+                                </c:if>
+                                <c:if test="${!empty oneProduct.img4}">
+                                    <div class="carousel-item">
+                                        <img alt="상품이미지가 없습니다." src="/upload/${oneProduct.img4}">
+                                    </div>
+                                </c:if>
+                                <c:if test="${!empty oneProduct.img5}">
+                                    <div class="carousel-item">
+                                        <img alt="상품이미지가 없습니다." src="/upload/${oneProduct.img5}">
+                                    </div>
+                                </c:if>
+                                <c:if test="${!empty oneProduct.img6}">
+                                    <div class="carousel-item">
+                                        <img alt="상품이미지가 없습니다." src="/upload/${oneProduct.img6}">
+                                    </div>
+                                </c:if>
+                                </c:if>
+                                
+                                 <!-- 비디오 없을 때 -->
+                                   <c:if test="${empty oneProduct.video}">
                                 <c:if test="${!empty oneProduct.img1}">
                                     <div class="carousel-item active">
                                         <img alt="상품이미지가 없습니다." src="/upload/${oneProduct.img1}">
@@ -297,6 +333,9 @@
                                         <img alt="상품이미지가 없습니다." src="/upload/${oneProduct.img6}">
                                     </div>
                                 </c:if>
+                                </c:if>
+                                
+                   
                                 
                             </div>
                             <button class="carousel-control-prev" type="button"


### PR DESCRIPTION
- 물품 상세페이지 carousel 
=> 동영상 있으면 동영상부터, 없으면 사진띄우게 로직 추가 
=> 동영상 플레이 중일 때, 커서를 동영상 쪽에 올리면 carousel 동작 정지 
( 플레이중일 때 자동으로 멈추게 하는 방법 확인 필요 ) 